### PR TITLE
Update line number property to return optional int vs str

### DIFF
--- a/src/pip_requirements_parser.py
+++ b/src/pip_requirements_parser.py
@@ -417,7 +417,7 @@ class RequirementLineMixin:
         return self.requirement_line and self.requirement_line.line  or None
 
     @property
-    def line_number(self) -> Optional[str]:
+    def line_number(self) -> Optional[int]:
         return self.requirement_line and self.requirement_line.line_number  or None
 
     @property


### PR DESCRIPTION
Update line number property to return optional int vs str.  Looks like this was just an oops.

Issue #8 