### PR TITLE
Fix the python version syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,7 @@ zip_safe = false
 
 setup_requires = setuptools_scm[toml] >= 4
 
-python_requires = >=3.6.*
+python_requires = >=3.6.0
 
 install_requires =
     packaging < 22.0.0


### PR DESCRIPTION
PDM does not consider `>= 3.6.*` a valid syntax, whereas `>= 3.6.0` expresses the same versions in a syntax that is valid.