### PR TITLE
fix: missing reference of `Path`

### DIFF
--- a/src/pip_requirements_parser.py
+++ b/src/pip_requirements_parser.py
@@ -75,6 +75,8 @@ from packaging.version import parse
 from packaging.version import Version
 
 from packaging_legacy_version import LegacyVersion
+
+from pathlib import Path
 """
 A pip requirements files parser, doing it as well as pip does it because it is
 based on pip's own code.


### PR DESCRIPTION
when `pip-requirements-parser` package is used to parse the requirements from the string using the `RequirementsFile.from_string()` method it invokes the following method

```python
    @classmethod
    def from_string(cls, text: str) -> "RequirementsFile":
        """
        Return a new RequirementsFile from a ``text`` string.

        Since pip requirements are deeply based on files, we create a temp file
        to feed to pip even if this feels a bit hackish.
        """
        tmpdir = None
        try:
            tmpdir = Path(str(tempfile.mkdtemp()))
            req_file = tmpdir / "requirements.txt"
            with open(req_file, "w") as rf:
                rf.write(text)
            return cls.from_file(filename=str(req_file), include_nested=False)
        finally:
            if tmpdir and tmpdir.exists():
                shutil.rmtree(path=str(tmpdir), ignore_errors=True)
```
but the following line invokes the `Path()` which raises the following exception
```python
    tmpdir = Path(str(tempfile.mkdtemp()))
```
**exception:**
```python
Traceback (most recent call last):
  File "{directory}/site-packages/pip_requirements_parser.py", line 270, in from_string
    tmpdir = Path(str(tempfile.mkdtemp()))
             ^^^^
NameError: name 'Path' is not defined
```

> ***This pr suggestes that fix***